### PR TITLE
Update metadata.json requirements/dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,13 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

Module is puppet 4 only and definately needs a stdlib newer than 1.0.0
I've picked 4.7.0 as the minimum stdlib version as that version claims
improved puppet 4 support.